### PR TITLE
kernel/contract: fix wrong key for iterator

### DIFF
--- a/kernel/contract/sandbox/mem_xmodel.go
+++ b/kernel/contract/sandbox/mem_xmodel.go
@@ -63,7 +63,6 @@ type treeIterator struct {
 	tree *redblacktree.Tree
 	iter *redblacktree.Iterator
 	end  []byte
-	key  []byte
 	err  error
 
 	iterDone bool
@@ -121,13 +120,6 @@ func (t *treeIterator) Next() bool {
 		t.iterDone = true
 		return false
 	}
-	_, key, err := parseRawKey(rawkey.([]byte))
-	if err != nil {
-		t.err = err
-		t.iterDone = true
-		return false
-	}
-	t.key = key
 	return true
 }
 
@@ -136,7 +128,7 @@ func (t *treeIterator) Key() []byte {
 	if t.iterDone {
 		return nil
 	}
-	return t.key
+	return t.Value().GetPureData().GetKey()
 }
 
 // 如果迭代器结束则Value返回nil

--- a/kernel/contract/sandbox/mem_xmodel_test.go
+++ b/kernel/contract/sandbox/mem_xmodel_test.go
@@ -18,7 +18,7 @@ func TestXModelIterator(t *testing.T) {
 
 	m := NewMemXModel()
 	for i := 0; i < N; i++ {
-		m.Put("test", []byte(keys[i]), nil)
+		putVersionedData(m, "test", []byte(keys[i]), []byte(keys[i]))
 	}
 
 	sort.Slice(keys, func(i, j int) bool {
@@ -51,7 +51,7 @@ func TestXModelRangeIterator(t *testing.T) {
 
 	m := NewMemXModel()
 	for i := 0; i < N; i++ {
-		m.Put("test", []byte(keys[i]), nil)
+		putVersionedData(m, "test", []byte(keys[i]), []byte(keys[i]))
 	}
 
 	sort.Slice(keys, func(i, j int) bool {


### PR DESCRIPTION
目前的XuperModel迭代器返回的key结构是`bucket/key`，应该把`bucket/`去掉。