### PR TITLE
ledger: reduce the memory allocation of the Merkle tree generation algorithm

### DIFF
--- a/bcs/ledger/xledger/ledger/ledger_hash_test.go
+++ b/bcs/ledger/xledger/ledger/ledger_hash_test.go
@@ -1,0 +1,37 @@
+package ledger
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	pb "github.com/xuperchain/xupercore/bcs/ledger/xledger/xldgpb"
+	"github.com/xuperchain/xupercore/lib/crypto/hash"
+)
+
+func TestMerkleHash(t *testing.T) {
+	left := []byte("hello")
+	right := []byte("world")
+	result := make([]byte, 32)
+	result = merkleDoubleSha256(left, right, result)
+
+	result1 := hash.DoubleSha256(append(left, right...))
+	if !bytes.Equal(result, result1) {
+		t.Fatal("not equal")
+	}
+}
+
+func BenchmarkNormalMerkle(b *testing.B) {
+	var txs []*pb.Transaction
+	for i := 0; i < 10000; i++ {
+		buf := make([]byte, 32)
+		rand.Read(buf)
+		txs = append(txs, &pb.Transaction{
+			Txid: buf,
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MakeMerkleTree(txs)
+	}
+}


### PR DESCRIPTION
## Description

What is the purpose of the change?

减少merkle算法的内存分配

一个区块里面的交易多了之后，生成默克尔树就比较耗时，这个提交减少了内存分配的次数，内存分配主要在sha256的生成上，每个double sha256都要进行2次分配。

这个PR使用了[arena](https://en.wikipedia.org/wiki/Region-based_memory_management)分配算法，一次性申请够所有的内存，再在每次计算sha256的时候单独分配, 另外使用了零分配的sha256函数来辅助计算sha256 

修复前:

```
BenchmarkNormalMerkle-160            100          11672176 ns/op         2067500 B/op      30017 allocs/op
```

修复后：
```
BenchmarkNormalMerkle-160            100          10394688 ns/op         1835604 B/op          5 allocs/op
```

对于一个`10000`个交易的区块，内存分配次数从`30017`降到了`5`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

