### PR TITLE
logs: use buffered file handler

### DIFF
--- a/lib/logs/buffer_handler.go
+++ b/lib/logs/buffer_handler.go
@@ -1,0 +1,63 @@
+package logs
+
+import (
+	"bufio"
+	"sync"
+	"time"
+
+	log "github.com/xuperchain/log15"
+)
+
+func mustBufferFileHandler(path string, fmtr log.Format, interval int, backupCount int) log.Handler {
+	h, err := bufferFileHandler(path, fmtr, interval, backupCount)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
+type syncWriter struct {
+	mutex sync.Mutex
+	w     *bufio.Writer
+}
+
+func newSyncWriter(w *bufio.Writer) *syncWriter {
+	return &syncWriter{
+		w: w,
+	}
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mutex.Lock()
+	n, err := s.w.Write(p)
+	s.mutex.Unlock()
+	return n, err
+}
+
+func (s *syncWriter) Flush() {
+	s.mutex.Lock()
+	s.w.Flush()
+	s.mutex.Unlock()
+}
+
+func bufferFileHandler(path string, fmtr log.Format, interval int, backupCount int) (log.Handler, error) {
+	f, err := log.NewTimeRotateWriter(path, interval, backupCount)
+	if err != nil {
+		return nil, err
+	}
+	w := newSyncWriter(bufio.NewWriter(f))
+
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		for range ticker.C {
+			w.Flush()
+		}
+	}()
+
+	h := log.FuncHandler(func(r *log.Record) error {
+		buf := fmtr.Format(r)
+		_, err = w.Write(buf)
+		return err
+	})
+	return h, nil
+}

--- a/lib/logs/log.go
+++ b/lib/logs/log.go
@@ -63,9 +63,9 @@ func OpenLog(lc *lconf.LogConf, logDir string) (LogDriver, error) {
 	// only valid if `RotateInterval` and `RotateBackups` greater than 0
 	var nmHandler, wfHandler log.Handler
 	if lc.RotateInterval > 0 && lc.RotateBackups > 0 {
-		nmHandler = log.Must.RotateFileHandler(
+		nmHandler = mustBufferFileHandler(
 			infoFile, lfmt, lc.RotateInterval, lc.RotateBackups)
-		wfHandler = log.Must.RotateFileHandler(
+		wfHandler = mustBufferFileHandler(
 			wfFile, lfmt, lc.RotateInterval, lc.RotateBackups)
 	} else {
 		nmHandler = log.Must.FileHandler(infoFile, lfmt)
@@ -85,9 +85,9 @@ func OpenLog(lc *lconf.LogConf, logDir string) (LogDriver, error) {
 	var lhd log.Handler
 	if lc.Console {
 		hstd := log.StreamHandler(os.Stderr, lfmt)
-		lhd = log.SyncHandler(log.MultiHandler(hstd, nmfileh, wffileh))
+		lhd = log.MultiHandler(hstd, nmfileh, wffileh)
 	} else {
-		lhd = log.SyncHandler(log.MultiHandler(nmfileh, wffileh))
+		lhd = log.MultiHandler(nmfileh, wffileh)
 	}
 	xlog.SetHandler(lhd)
 

--- a/lib/logs/log_test.go
+++ b/lib/logs/log_test.go
@@ -1,0 +1,33 @@
+package logs
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/xuperchain/xupercore/lib/logs/config"
+)
+
+func BenchmarkLogging(b *testing.B) {
+	tmpdir, err := ioutil.TempDir("", "xchain-log")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	conf := config.GetDefLogConf()
+	conf.Console = false
+	log, err := OpenLog(conf, tmpdir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	logHandle = log
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			l, _ := NewLogger("", "test")
+			l.Info("test logging benchmark", "key1", "k1", "key2", "k2")
+		}
+	})
+}


### PR DESCRIPTION
## Description

现有的日志库有如下地方比较耗时:

- 直接使用`os.File.Write`来写入每一条日志，系统调用开销比较大。
- 日志的格式化在锁内，并发写入耗时比较大

修复方案：
- 使用`bufio.Writer`来减少系统调用次数。
- 在锁外格式化日志，在锁内写入日志buffer。

修复前：
```
BenchmarkLogging-4        114116             10351 ns/op
```

修复后：
```
BenchmarkLogging-4        374816              3238 ns/op
```

差不多有`3`倍的性能提升，结合 #228 差不多有`7`倍的性能提升。可以满足目前大部分日志场景。



