### PR TITLE
fix: ignore docker setup  as it hangs because docker daemon can not be started

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,6 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - name: setup Docker
-      uses: docker-practice/actions-setup-docker@master
-
-    - name: pull unit test related images
-      run: |
-        docker pull openjdk:8u292-slim-buster && docker pull ubuntu:18.04
-
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test


### PR DESCRIPTION
## Description

ignore docker setup  as it hangs because docker daemon can not be started

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
