### PR TITLE
fix confirm tx and p2p map cocurrent read

### DIFF
--- a/bcs/ledger/xledger/tx/mempool_test.go
+++ b/bcs/ledger/xledger/tx/mempool_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/xuperchain/xupercore/protos"
 )
 
-var sum = 100
+var sum = 1000
 
 func TestPutOrphanTx(t *testing.T) {
 	econf, err := mock.NewEnvConfForTest()
@@ -135,11 +135,16 @@ func run(b *testing.B, t *testing.T) {
 	result := batchTx(m)
 	printMempool(m)
 	fmt.Println("确认一笔交易")
-	e := m.ConfirmTx(result[80]) //
-	if e != nil {
-		panic(e)
-	}
-	fmt.Println("confirm tx:", string(result[40].Txid))
+	cb := time.Now()
+	// for i := 0; i < 10000; i++ {
+	// 	e := m.ConfirmTx(result[i]) //
+	// 	if e != nil {
+	// 		panic(e)
+	// 	}
+	// }
+	m.BatchConfirmTx(result[:10000])
+
+	fmt.Println("confirm tx:", string(result[40].Txid), "耗时=", time.Since(cb))
 
 	// deleteID := string(result[80].Txid) //"8001"
 	// fmt.Println("delete tx:", deleteID)

--- a/bcs/ledger/xledger/tx/tx.go
+++ b/bcs/ledger/xledger/tx/tx.go
@@ -211,7 +211,7 @@ func (t *Tx) GetUnconfirmedTx(dedup bool, sizeLimit int) ([]*pb.Transaction, err
 	}
 
 	t.Mempool.Range(f)
-	t.UnconfirmTxAmount = int64(len(result))
+	t.UnconfirmTxAmount = int64(t.Mempool.GetTxCounnt())
 	t.log.Debug("Tx GetUnconfirmedTx", "UnconfirmTxCount", t.UnconfirmTxAmount)
 	return result, nil
 }
@@ -283,7 +283,7 @@ func (t *Tx) SortUnconfirmedTx(sizeLimit int) ([]*pb.Transaction, []*pb.Transact
 		t.log.Info("average unconfirm delay", "micro-senconds", microSec, "count", txMapSize)
 		t.AvgDelay = microSec
 	}
-	t.UnconfirmTxAmount = txMapSize
+	t.UnconfirmTxAmount = int64(t.Mempool.GetTxCounnt())
 	return result, delayedTxs, nil
 }
 

--- a/kernel/network/p2p/dispatcher.go
+++ b/kernel/network/p2p/dispatcher.go
@@ -125,10 +125,6 @@ func (d *dispatcher) Dispatch(msg *pb.XuperMessage, stream Stream) error {
 		return ErrStreamNil
 	}
 
-	if _, ok := d.mc[msg.GetHeader().GetType()]; !ok {
-		return ErrNotRegister
-	}
-
 	d.mu.RLock()
 	ctx.GetTimer().Mark("lock")
 	if _, ok := d.mc[msg.GetHeader().GetType()]; !ok {


### PR DESCRIPTION
## Description

修改 confirem tx 耗时太长，以及删除 p2p 中的多余代码。

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


