### PR TITLE
Compatible container runtime, listening port

### DIFF
--- a/bcs/network/p2pv1/server.go
+++ b/bcs/network/p2pv1/server.go
@@ -141,7 +141,20 @@ func (p *P2PServerV1) serve() {
 	if err != nil {
 		panic(fmt.Sprintf("address error: address=%s", err))
 	}
-
+	
+	
+	//Compatible container runtime, listening port
+	portIndex := strings.LastIndex(ip, ":")
+	if portIndex > 0 {
+		port := ip[portIndex:]
+		if network == "ip4" {
+			ip = "0.0.0.0" + port
+		} else if network == "ip6" {
+			ip = "[::]" + port
+		}
+	}
+	
+	
 	l, err := net.Listen(network, ip)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Description

What is the purpose of the change?

Compatible with the container environment, change the listening IP to 0.0.0.0 or [::]

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Brief of your solution

Change the listening IP to 0.0.0.0 or [::]

## How Has This Been Tested?

K8s deploys XPOA 3 nodes