### PR TITLE
miner: make sync block more faster

### DIFF
--- a/kernel/engines/xuperos/miner/miner.go
+++ b/kernel/engines/xuperos/miner/miner.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	tickOnCalcBlock           = time.Second
-	syncOnstatusChangeTimeout = 10 * time.Second
+	syncOnstatusChangeTimeout = 1 * time.Minute
 
 	statusFollowing = 0
 	statusMining    = 1
@@ -74,6 +74,13 @@ func (t *Miner) Start() {
 
 	var err error
 	t.status = statusFollowing
+
+	ctx := &xctx.BaseCtx{
+		XLog:  t.log,
+		Timer: timer.NewXTimer(),
+	}
+	t.syncWithNeighbors(ctx)
+
 	// 启动矿工循环
 	for !t.IsExit() {
 		err = t.step()

--- a/kernel/engines/xuperos/miner/sync.go
+++ b/kernel/engines/xuperos/miner/sync.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	batchBlockNumber    = 4
+	batchBlockNumber    = 2
 	maxBatchBlockNumber = 10
 
 	peersKey = "peers"
@@ -151,12 +151,20 @@ func (t *Miner) syncWithLongestChain(ctx xctx.XContext) (int, error) {
 	return realSize, nil
 }
 
-// syncWithNeighbors 向p2p邻居节点进行一次区块同步
+// syncWithNeighbors 向p2p邻居节点进行区块同步
 func (t *Miner) syncWithNeighbors(ctx xctx.XContext) error {
-	currentHeight := t.ctx.Ledger.GetMeta().TrunkHeight
-	height := currentHeight + 1
-	_, err := t.syncBlockWithHeight(ctx, height, batchBlockNumber)
-	return err
+	for {
+		currentHeight := t.ctx.Ledger.GetMeta().TrunkHeight
+		height := currentHeight + 1
+		size, err := t.syncBlockWithHeight(ctx, height, batchBlockNumber)
+		if err != nil {
+			return err
+		}
+		if size <= 0 {
+			break
+		}
+	}
+	return nil
 }
 
 func (t *Miner) syncBlockWithHeight(ctx xctx.XContext, height int64, size int) (int, error) {

--- a/kernel/network/config/config.go
+++ b/kernel/network/config/config.go
@@ -17,7 +17,7 @@ const (
 	DefaultNetIsHidden       = false
 	DefaultMaxStreamLimits   = 1024
 	DefaultMaxMessageSize    = 128
-	DefaultTimeout           = 3
+	DefaultTimeout           = 30
 	DefaultStreamIPLimitSize = 10
 	DefaultMaxBroadcastPeers = 20
 	DefaultServiceName       = "localhost"


### PR DESCRIPTION
## Description

目前的区块同步为定时同步，为了解决节点落后区块太多导致的区块同步慢的问题，采用了如下解决方案：

- 节点启动的时候，主动进行一次全量区块同步
- 区块同步主循环中尽量一次多同步区块
