### PR TITLE
fix recoverUnconfirmedTx ledger check tx

### DIFF
--- a/bcs/ledger/xledger/state/state.go
+++ b/bcs/ledger/xledger/state/state.go
@@ -1257,7 +1257,11 @@ func (t *State) recoverUnconfirmedTx(undoList []*pb.Transaction) {
 
 		// 检查交易是否已经被确认（被其他节点打包倒区块并广播了过来）
 		isConfirm, err := t.sctx.Ledger.HasTransaction(tx.Txid)
-		if err != nil && isConfirm {
+		if err != nil {
+			t.log.Error("recoverUnconfirmedTx fail", "checkLedgerHasTxError", err)
+			return
+		}
+		if isConfirm {
 			confirmCnt++
 			t.log.Info("this tx has been confirmed,ignore recover", "txid", hex.EncodeToString(tx.Txid))
 			continue


### PR DESCRIPTION
## Description

walk 时回滚未确认交易再单独一个协程中再次执行交易，判断交易是否在账本中时，需要先判断 error 再判断是否存在账本。