### PR TITLE
ledger: copy on write block cache

### DIFF
--- a/bcs/ledger/xledger/ledger/branch_manage.go
+++ b/bcs/ledger/xledger/ledger/branch_manage.go
@@ -66,7 +66,7 @@ func (l *Ledger) HandleFork(oldTip []byte, newTip []byte, batchWrite kvdb.Batch)
 	}
 	// 将老分支剪一下
 	for !bytes.Equal(oldTip, commonParentBlockid) {
-		oldBlock, oldBlockErr := l.fetchBlock(oldTip)
+		oldBlock, oldBlockErr := l.fetchBlockForModify(oldTip)
 		if oldBlockErr != nil {
 			return nil, oldBlockErr
 		}
@@ -79,14 +79,14 @@ func (l *Ledger) HandleFork(oldTip []byte, newTip []byte, batchWrite kvdb.Batch)
 		}
 	}
 	// 将新分支修一下
-	newBlock, newBlockErr := l.fetchBlock(newTip)
+	newBlock, newBlockErr := l.fetchBlockForModify(newTip)
 	if newBlockErr != nil {
 		return nil, newBlockErr
 	}
 	newPreBlockid := newBlock.PreHash
 	nextHash := []byte{}
 	for !bytes.Equal(newTip, commonParentBlockid) {
-		newBlock, newBlockErr := l.fetchBlock(newTip)
+		newBlock, newBlockErr := l.fetchBlockForModify(newTip)
 		if newBlockErr != nil {
 			return nil, newBlockErr
 		}


### PR DESCRIPTION
## Description

代码中存在着从block cache中获取block之后修改`NextHash`字段的行为，另外一个并发的先获取block再marshal的协程就会触发竞争，导致panic。

这个PR在每个写block的地方都拷贝了一份。

update #251 
