### PR TITLE
smr: update the qc-tree and the pacemaker in KeepUpWithBlock.

### DIFF
--- a/kernel/consensus/base/driver/chained-bft/pacemaker.go
+++ b/kernel/consensus/base/driver/chained-bft/pacemaker.go
@@ -1,6 +1,8 @@
 package chained_bft
 
 import (
+	"errors"
+
 	"github.com/xuperchain/xupercore/kernel/consensus/base/driver/chained-bft/storage"
 )
 
@@ -15,6 +17,10 @@ type PacemakerInterface interface {
 	AdvanceView(qc storage.QuorumCertInterface) (bool, error)
 }
 
+var (
+	ErrNilQC = errors.New("pacemaker meets a nil qc")
+)
+
 // DefaultPaceMaker 是一个PacemakerInterface的默认实现，我们与PacemakerInterface放置在一起，方便查看
 // PacemakerInterface的新实现直接直接替代DefaultPaceMaker即可
 // The Pacemaker keeps track of votes and of time.
@@ -25,6 +31,9 @@ type DefaultPaceMaker struct {
 }
 
 func (p *DefaultPaceMaker) AdvanceView(qc storage.QuorumCertInterface) (bool, error) {
+	if qc == nil {
+		return false, ErrNilQC
+	}
 	r := qc.GetProposalView()
 	if r+1 > p.CurrentView {
 		p.CurrentView = r + 1

--- a/kernel/consensus/base/driver/chained-bft/smr.go
+++ b/kernel/consensus/base/driver/chained-bft/smr.go
@@ -97,6 +97,13 @@ func NewSmr(bcName, address string, log logs.Logger, p2p cctx.P2pCtxInConsensus,
 	}
 	// smr初始值装载
 	s.localProposal.Store(utils.F(qcTree.GetRootQC().In.GetProposalId()), 0)
+	if qcTree.GetHighQC() != nil {
+		s.ledgerState = int64(qcTree.GetHighQC().In.GetProposalView())
+	} else if qcTree.GetGenericQC() != nil {
+		s.ledgerState = int64(qcTree.GetGenericQC().In.GetProposalView())
+	} else {
+		s.ledgerState = int64(qcTree.GetRootQC().In.GetProposalView())
+	}
 	return s
 }
 
@@ -186,12 +193,10 @@ func (s *Smr) KeepUpWithBlock(block cctx.BlockInterface, justify storage.QuorumC
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	if justify != nil {
-		s.updateJustifyQcStatus(justify)
-	}
+	s.updateJustifyQcStatus(justify)
 	if validators != nil {
 		err := s.ProcessProposal(block.GetHeight(), block.GetBlockid(), block.GetPreHash(), validators)
-		if err != nil && err != ErrSameProposalNotify {
+		if err != nil && err != ErrSameProposalNotify && err != ErrTooLowNewProposal {
 			return err
 		}
 	}
@@ -201,7 +206,10 @@ func (s *Smr) KeepUpWithBlock(block cctx.BlockInterface, justify storage.QuorumC
 	if err != nil {
 		return err
 	}
-	s.log.Debug("consensus:smr:KeepUpWithBlock: Now HighQC", "highQC", utils.F(s.getHighQC().GetProposalId()), "err", err, "blockId", utils.F(block.GetBlockid()))
+	s.qcTree.UpdateCommit(block.GetPreHash())
+	s.pacemaker.AdvanceView(justify)
+	s.log.Debug("consensus:smr:KeepUpWithBlock: current parameters: ", "highQC", utils.F(s.getHighQC().GetProposalId()), "blockId", utils.F(block.GetBlockid()),
+		"pacemaker view", s.pacemaker.GetCurrentView(), "QCTree Root", utils.F(s.qcTree.GetRootQC().In.GetProposalId()))
 	return nil
 }
 
@@ -335,7 +343,7 @@ func (s *Smr) ProcessProposal(viewNumber int64, proposalID []byte, parentID []by
 	}
 	if s.pacemaker.GetCurrentView() != s.qcTree.GetGenesisQC().In.GetProposalView()+1 &&
 		s.qcTree.GetLockedQC() != nil && s.pacemaker.GetCurrentView() < s.qcTree.GetLockedQC().In.GetProposalView() {
-		s.log.Debug("smr::ProcessProposal error", "error", ErrTooLowNewProposal, "pacemaker view", s.pacemaker.GetCurrentView(), "lockQC view",
+		s.log.Error("smr::ProcessProposal error", "error", ErrTooLowNewProposal, "pacemaker view", s.pacemaker.GetCurrentView(), "lockQC view",
 			s.qcTree.GetLockedQC().In.GetProposalView())
 		return ErrTooLowNewProposal
 	}
@@ -374,7 +382,7 @@ func (s *Smr) ProcessProposal(viewNumber int64, proposalID []byte, parentID []by
 		s.log.Error("smr::ProcessProposal::NewMessage error")
 		return ErrP2PInternalErr
 	}
-	go s.p2p.SendMessage(createNewBCtx(), netMsg, p2p.WithAccounts(validatesIpInfo))
+	go s.p2p.SendMessage(createNewBCtx(), netMsg, p2p.WithAccounts(s.removeLocalValidator(validatesIpInfo)))
 	s.localProposal.Store(utils.F(proposalID), proposal.Timestamp)
 	s.log.Debug("smr:ProcessProposal::new proposal has been made", "address", s.address, "proposalID", utils.F(proposalID))
 	return nil
@@ -695,6 +703,16 @@ func (s *Smr) enforceUpdateHighQC(inProposalId []byte) (bool, error) {
 		return false, nil
 	}
 	return true, s.qcTree.EnforceUpdateHighQC(inProposalId)
+}
+
+func (s *Smr) removeLocalValidator(in []string) []string {
+	var out []string
+	for _, addr := range in {
+		if addr != s.address {
+			out = append(out, addr)
+		}
+	}
+	return out
 }
 
 func createNewBCtx() *xctx.BaseCtx {

--- a/kernel/consensus/base/driver/chained-bft/storage/qc_tree.go
+++ b/kernel/consensus/base/driver/chained-bft/storage/qc_tree.go
@@ -104,7 +104,6 @@ func InitQCTree(startHeight int64, ledger cctx.LedgerRely, log logs.Logger) *QCP
 			genesis:    gNode,
 			root:       gNode,
 			highQC:     gNode,
-			commitQC:   gNode,
 			log:        log,
 			orphanList: list.New(),
 			orphanMap:  make(map[string]bool),


### PR DESCRIPTION
Fixes # (issue)
Fix the bug that a validator cannot sync blocks after pruning the ledger.

## Brief of your solution
Update the QCTree and the pacemaker in KeepUpWithBlock.