### PR TITLE
fix load tx from disk faild and make merkle tree hash panic

### DIFF
--- a/bcs/ledger/xledger/tx/mempool.go
+++ b/bcs/ledger/xledger/tx/mempool.go
@@ -811,12 +811,8 @@ func (m *Mempool) processOrphansToUnconfirmed(orphans []*Node) {
 			delete(m.orphans, n.txid)
 			m.unconfirmed[n.txid] = n
 			for _, cn := range n.getAllChildren() {
-				q.PushBack(cn)
-			}
-		} else {
-			for _, fn := range n.getAllParent() {
-				if _, ok := m.orphans[fn.txid]; ok {
-					q.PushBack(fn)
+				if _, ok := m.orphans[cn.txid]; ok {
+					q.PushBack(cn)
 				}
 			}
 		}


### PR DESCRIPTION
从磁盘加载未确认交易时，mempool 添加交易时如果此交易非孤儿交易，那么要检查此交易得所有子交易，判断有没有孤儿交易可以移动到未确认交易表。之前因为同样遍历了子交易得父交易，可能导致将虚拟的孤儿交易加入到未确认交易表。