### PR TITLE
fix load tx from disk faild and make merkle tree hash panic (#270)

### DIFF
--- a/bcs/ledger/xledger/tx/mempool.go
+++ b/bcs/ledger/xledger/tx/mempool.go
@@ -811,12 +811,8 @@ func (m *Mempool) processOrphansToUnconfirmed(orphans []*Node) {
 			delete(m.orphans, n.txid)
 			m.unconfirmed[n.txid] = n
 			for _, cn := range n.getAllChildren() {
-				q.PushBack(cn)
-			}
-		} else {
-			for _, fn := range n.getAllParent() {
-				if _, ok := m.orphans[fn.txid]; ok {
-					q.PushBack(fn)
+				if _, ok := m.orphans[cn.txid]; ok {
+					q.PushBack(cn)
 				}
 			}
 		}


### PR DESCRIPTION
修复裁剪账本或者程序重启时，从磁盘加载未确认交易时 mempool 导致 panic 问题。