### PR TITLE
consensus: delete the RegisterKernMethod panic in registry_imp & allo…

### DIFF
--- a/bcs/consensus/tdpos/tdpos.go
+++ b/bcs/consensus/tdpos/tdpos.go
@@ -92,9 +92,7 @@ func NewTdposConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Co
 		contractGetTdposInfos:     tdpos.runGetTdposInfos,
 	}
 	for method, f := range tdposKMethods {
-		if _, err := cCtx.Contract.GetKernRegistry().GetKernMethod(schedule.bindContractBucket, method); err != nil {
-			cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
-		}
+		cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
 	}
 
 	// 凡属于共识升级的逻辑，新建的Tdpos实例将直接将当前值置为true，原因是上一共识模块已经在当前值生成了高度为trigger height的区块，新的实例会再生成一边

--- a/bcs/consensus/tdpos/tdpos.go
+++ b/bcs/consensus/tdpos/tdpos.go
@@ -92,6 +92,8 @@ func NewTdposConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Co
 		contractGetTdposInfos:     tdpos.runGetTdposInfos,
 	}
 	for method, f := range tdposKMethods {
+		// 若有历史句柄，删除老句柄
+		cCtx.Contract.GetKernRegistry().UnregisterKernMethod(schedule.bindContractBucket, method)
 		cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
 	}
 

--- a/bcs/consensus/tdpos/tdpos_test.go
+++ b/bcs/consensus/tdpos/tdpos_test.go
@@ -16,6 +16,7 @@ import (
 
 func getTdposConsensusConf() string {
 	return `{
+		"version": "2",
         "timestamp": "1559021720000000000",
         "proposer_num": "2",
         "period": "3000",
@@ -31,6 +32,7 @@ func getTdposConsensusConf() string {
 
 func getBFTTdposConsensusConf() string {
 	return `{
+		"version": "2",
         "timestamp": "1559021720000000000",
         "proposer_num": "2",
         "period": "3000",

--- a/bcs/consensus/xpoa/common.go
+++ b/bcs/consensus/xpoa/common.go
@@ -30,7 +30,7 @@ const (
 )
 
 type xpoaConfig struct {
-	Version int64 `json:"version,omitempty"`
+	Version string `json:"version,omitempty"`
 	// 每个候选人每轮出块个数
 	BlockNum int64 `json:"block_num"`
 	// 单位为毫秒

--- a/bcs/consensus/xpoa/schedule.go
+++ b/bcs/consensus/xpoa/schedule.go
@@ -2,6 +2,7 @@ package xpoa
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	common "github.com/xuperchain/xupercore/kernel/consensus/base/common"
@@ -35,13 +36,18 @@ type xpoaSchedule struct {
 }
 
 func NewXpoaSchedule(xconfig *xpoaConfig, cCtx context.ConsensusCtx, startHeight int64) *xpoaSchedule {
+	version, err := strconv.ParseInt(xconfig.Version, 10, 64)
+	if err != nil {
+		cCtx.XLog.Error("Xpoa::NewXpoaSchedule::Parse version error.", "err", err)
+		return nil
+	}
 	s := xpoaSchedule{
 		address:            cCtx.Network.PeerInfo().Account,
 		period:             xconfig.Period,
 		blockNum:           xconfig.BlockNum,
 		startHeight:        startHeight,
 		consensusName:      "poa",
-		consensusVersion:   xconfig.Version,
+		consensusVersion:   version,
 		bindContractBucket: poaBucket,
 		ledger:             cCtx.Ledger,
 		log:                cCtx.XLog,

--- a/bcs/consensus/xpoa/xpoa.go
+++ b/bcs/consensus/xpoa/xpoa.go
@@ -3,6 +3,7 @@ package xpoa
 import (
 	"bytes"
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/xuperchain/xupercore/kernel/common/xcontext"
@@ -65,7 +66,11 @@ func NewXpoaConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Con
 		cCtx.XLog.Error("consensus:xpoa:NewXpoaConsensus: xpoa struct unmarshal error", "error", err)
 		return nil
 	}
-
+	version, err := strconv.ParseInt(xconfig.Version, 10, 64)
+	if err != nil {
+		cCtx.XLog.Error("consensus:xpoa:NewXpoaConsensus: version error", "error", err)
+		return nil
+	}
 	// create xpoaSchedule
 	schedule := NewXpoaSchedule(xconfig, cCtx, cCfg.StartHeight)
 	if schedule == nil {
@@ -75,7 +80,7 @@ func NewXpoaConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Con
 	// 创建status实例
 	status := &XpoaStatus{
 		Name:        "poa",
-		Version:     xconfig.Version,
+		Version:     version,
 		StartHeight: cCfg.StartHeight,
 		Index:       cCfg.Index,
 		election:    schedule,

--- a/bcs/consensus/xpoa/xpoa.go
+++ b/bcs/consensus/xpoa/xpoa.go
@@ -100,7 +100,9 @@ func NewXpoaConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Con
 		contractGetValidates: xpoa.methodGetValidates,
 	}
 	for method, f := range xpoaKMethods {
-			cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
+		// 若有历史句柄，删除老句柄
+		cCtx.Contract.GetKernRegistry().UnregisterKernMethod(schedule.bindContractBucket, method)
+		cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
 	}
 
 	// 凡属于共识升级的逻辑，新建的Xpoa实例将直接将当前值置为true，原因是上一共识模块已经在当前值生成了高度为trigger height的区块，新的实例会再生成一边

--- a/bcs/consensus/xpoa/xpoa.go
+++ b/bcs/consensus/xpoa/xpoa.go
@@ -100,9 +100,7 @@ func NewXpoaConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Con
 		contractGetValidates: xpoa.methodGetValidates,
 	}
 	for method, f := range xpoaKMethods {
-		if _, err := cCtx.Contract.GetKernRegistry().GetKernMethod(schedule.bindContractBucket, method); err != nil {
 			cCtx.Contract.GetKernRegistry().RegisterKernMethod(schedule.bindContractBucket, method, f)
-		}
 	}
 
 	// 凡属于共识升级的逻辑，新建的Xpoa实例将直接将当前值置为true，原因是上一共识模块已经在当前值生成了高度为trigger height的区块，新的实例会再生成一边

--- a/bcs/consensus/xpoa/xpoa_test.go
+++ b/bcs/consensus/xpoa/xpoa_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestUnmarshalConfig(t *testing.T) {
 	cStr := `{
+		"version": "2",
 		"period": 3000,
 		"block_num": 10,
 		"init_proposer": {
@@ -33,6 +34,7 @@ func TestUnmarshalConfig(t *testing.T) {
 
 func getXpoaConsensusConf() string {
 	return `{
+		"version": "2",
         "period":3000,
         "block_num":10,
         "init_proposer": {
@@ -43,6 +45,7 @@ func getXpoaConsensusConf() string {
 
 func getBFTXpoaConsensusConf() string {
 	return `{
+		"version": "2",
         "period":3000,
         "block_num":10,
         "init_proposer": {

--- a/kernel/consensus/mock/mock_pluggable_consensus.go
+++ b/kernel/consensus/mock/mock_pluggable_consensus.go
@@ -134,7 +134,7 @@ func (m *FakeMeta) GetTipBlockid() []byte {
 }
 
 func GetGenesisConsensusConf() []byte {
-	return []byte("{\"name\":\"fake\",\"config\":\"\"}")
+	return []byte("{\"name\":\"fake\",\"config\":\"{}\"}")
 }
 
 type FakeLedger struct {

--- a/kernel/consensus/mock/mock_pluggable_consensus.go
+++ b/kernel/consensus/mock/mock_pluggable_consensus.go
@@ -388,6 +388,10 @@ func (r *FakeRegistry) RegisterKernMethod(contract, method string, handler contr
 	r.M[method] = handler
 }
 
+func (r *FakeRegistry) UnregisterKernMethod(ctract, method string) {
+	return
+}
+
 func (r *FakeRegistry) GetKernMethod(contract, method string) (contract.KernMethod, error) {
 	return nil, nil
 }

--- a/kernel/consensus/pluggable_consensus_test.go
+++ b/kernel/consensus/pluggable_consensus_test.go
@@ -229,19 +229,20 @@ func TestNewPluggableConsensus(t *testing.T) {
 }
 
 func GetNewConsensusConf() []byte {
-	return []byte("{\"name\":\"another\",\"config\":\"\"}")
+	return []byte("{\"name\":\"another\",\"config\":\"{}\"}")
 }
 
 func GetWrongConsensusConf() []byte {
-	return []byte("{\"name\":\"\",\"config\":\"\"}")
+	return []byte("{\"name\":\"\",\"config\":\"{}\"}")
 }
 
 func NewUpdateArgs() map[string][]byte {
 	a := make(map[string]interface{})
 	a["name"] = "another"
 	a["config"] = map[string]interface{}{
-		"miner":  "TeyyPLpp9L7QAcxHangtcHTu7HUZ6iydY",
-		"period": "3000",
+		"version": "1",
+		"miner":   "TeyyPLpp9L7QAcxHangtcHTu7HUZ6iydY",
+		"period":  "3000",
 	}
 	ab, _ := json.Marshal(&a)
 	r := map[string][]byte{

--- a/kernel/contract/kernel.go
+++ b/kernel/contract/kernel.go
@@ -2,6 +2,7 @@ package contract
 
 type KernRegistry interface {
 	RegisterKernMethod(contract, method string, handler KernMethod)
+	UnregisterKernMethod(ctract, method string)
 	// RegisterShortcut 用于contractName缺失的时候选择哪个合约名字和合约方法来执行对应的kernel合约
 	RegisterShortcut(oldmethod, contract, method string)
 	GetKernMethod(contract, method string) (KernMethod, error)

--- a/kernel/contract/manager/registry_impl.go
+++ b/kernel/contract/manager/registry_impl.go
@@ -31,13 +31,20 @@ func (r *registryImpl) RegisterKernMethod(ctract, method string, handler contrac
 		contractMap = make(map[string]contract.KernMethod)
 		r.methods[ctract] = contractMap
 	}
-	/*
-		_, ok = contractMap[method]
-		if ok {
-			panic(fmt.Sprintf("kernel method `%s' for `%s' exists", method, ctract))
-		}
-	*/
+	_, ok = contractMap[method]
+	if ok {
+		panic(fmt.Sprintf("kernel method `%s' for `%s' exists", method, ctract))
+	}
 	contractMap[method] = handler
+}
+
+func (r *registryImpl) UnregisterKernMethod(ctract, method string) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if contractMap, ok := r.methods[ctract]; ok {
+		delete(contractMap, method)
+	}
 }
 
 func (r *registryImpl) RegisterShortcut(oldmethod, contract, method string) {

--- a/kernel/contract/manager/registry_impl.go
+++ b/kernel/contract/manager/registry_impl.go
@@ -31,10 +31,12 @@ func (r *registryImpl) RegisterKernMethod(ctract, method string, handler contrac
 		contractMap = make(map[string]contract.KernMethod)
 		r.methods[ctract] = contractMap
 	}
-	_, ok = contractMap[method]
-	if ok {
-		panic(fmt.Sprintf("kernel method `%s' for `%s' exists", method, ctract))
-	}
+	/*
+		_, ok = contractMap[method]
+		if ok {
+			panic(fmt.Sprintf("kernel method `%s' for `%s' exists", method, ctract))
+		}
+	*/
 	contractMap[method] = handler
 }
 

--- a/kernel/engines/xuperos/parachain/parachain_manager.go
+++ b/kernel/engines/xuperos/parachain/parachain_manager.go
@@ -46,7 +46,9 @@ func NewParaChainManager(ctx *ParaChainCtx) (*Manager, error) {
 		"stopChain":   t.stopChain,
 	}
 	for method, f := range kMethods {
-		register.RegisterKernMethod(ParaChainKernelContract, method, f)
+		if _, err := register.GetKernMethod(ParaChainKernelContract, method); err != nil {
+			register.RegisterKernMethod(ParaChainKernelContract, method, f)
+		}
 	}
 
 	// 仅主链绑定handleCreateChain 从链上下文中获取链绑定的异步任务worker

--- a/kernel/engines/xuperos/parachain/parachain_manager.go
+++ b/kernel/engines/xuperos/parachain/parachain_manager.go
@@ -46,9 +46,7 @@ func NewParaChainManager(ctx *ParaChainCtx) (*Manager, error) {
 		"stopChain":   t.stopChain,
 	}
 	for method, f := range kMethods {
-		if _, err := register.GetKernMethod(ParaChainKernelContract, method); err != nil {
-			register.RegisterKernMethod(ParaChainKernelContract, method, f)
-		}
+		register.RegisterKernMethod(ParaChainKernelContract, method, f)
 	}
 
 	// 仅主链绑定handleCreateChain 从链上下文中获取链绑定的异步任务worker


### PR DESCRIPTION
Delete the RegisterKernMethod panic in registry_imp & allow consensus upgrade with the same name & add CheckConsensusVersion.
Configuration should only store a version parameter when rolling back and should have an upper version parameter with other configs when updating a new consensus item.
