### PR TITLE
fix play block failed when utxo cache too small

### DIFF
--- a/bcs/ledger/xledger/state/state.go
+++ b/bcs/ledger/xledger/state/state.go
@@ -830,8 +830,9 @@ func (t *State) doTxSync(tx *pb.Transaction) error {
 }
 
 func (t *State) doTxInternal(tx *pb.Transaction, batch kvdb.Batch, cacheFiller *utxo.CacheFiller) error {
+	t.utxo.CleanBatchCache(batch) // 根据 batch 清理缓存。
 	if tx.GetModifyBlock() == nil || (tx.GetModifyBlock() != nil && !tx.ModifyBlock.Marked) {
-		if err := t.utxo.CheckInputEqualOutput(tx); err != nil {
+		if err := t.utxo.CheckInputEqualOutput(tx, batch); err != nil {
 			return err
 		}
 	}
@@ -851,6 +852,7 @@ func (t *State) doTxInternal(tx *pb.Transaction, batch kvdb.Batch, cacheFiller *
 		batch.Delete([]byte(utxoKey)) // 删除用掉的utxo
 		t.utxo.UtxoCache.Remove(string(addr), utxoKey)
 		t.utxo.SubBalance(addr, big.NewInt(0).SetBytes(txInput.Amount))
+		t.utxo.RemoveBatchCache(utxoKey) // 删除 batch cache 中用掉的 utxo。
 	}
 	for offset, txOutput := range tx.TxOutputs {
 		addr := txOutput.ToAddr
@@ -883,6 +885,7 @@ func (t *State) doTxInternal(tx *pb.Transaction, batch kvdb.Batch, cacheFiller *
 			// coinbase交易（包括创始块和挖矿奖励)会增加系统的总资产
 			t.utxo.UpdateUtxoTotal(uItem.Amount, batch, true)
 		}
+		t.utxo.InsertBatchCache(utxoKey, uItem) // batch cache 中插入当前交易产生的 utxo。
 	}
 	return nil
 }

--- a/bcs/ledger/xledger/state/utxo/utxo_test.go
+++ b/bcs/ledger/xledger/state/utxo/utxo_test.go
@@ -189,7 +189,7 @@ func TestBasicFunc(t *testing.T) {
 		txOutput.Amount = delta.Bytes()
 		tx1.TxOutputs = append(tx1.TxOutputs, txOutput)
 	}
-	err = utxoHandle.CheckInputEqualOutput(tx1)
+	err = utxoHandle.CheckInputEqualOutput(tx1, nil)
 	if err != nil {
 		t.Log(err)
 	}


### PR DESCRIPTION
当utxo cache设置太小时，非旷工节点执行一个区块时有可能执行失败。解决方案是针对执行区块时将区块内所有交易的 utxo 缓存起来。