### PR TITLE
问题：p2p连接显示"dial to self attempted"错误

### DIFF
--- a/bcs/network/p2pv2/stream_pool.go
+++ b/bcs/network/p2pv2/stream_pool.go
@@ -7,6 +7,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
+	swarm "github.com/libp2p/go-libp2p-swarm"
 
 	xctx "github.com/xuperchain/xupercore/kernel/common/xcontext"
 	nctx "github.com/xuperchain/xupercore/kernel/network/context"
@@ -75,6 +76,10 @@ func (sp *StreamPool) Get(ctx xctx.XContext, peerId peer.ID) (*Stream, error) {
 
 	netStream, err := sp.srv.host.NewStream(sp.ctx, peerId, protocol.ID(protocolID))
 	if err != nil {
+		if errors.Is(err, swarm.ErrDialToSelf) {
+			ctx.GetLog().Trace("new net stream error", "peerId", peerId, "error", err)
+			return nil, ErrNewStream
+		}
 		ctx.GetLog().Warn("new net stream error", "peerId", peerId, "error", err)
 		return nil, ErrNewStream
 	}


### PR DESCRIPTION
代码中关于peerids的获取是经过kaddht句柄从底层libp2p库获取到然后经过multi过滤器过滤，此处暂未处理获取peerids的流程，仅当上述错误出现时由warn级别改为trace日志级别

## Description

What is the purpose of the change?
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
