### PR TITLE
日志中出现大量warn级别"dial to self attempted"的优化

### DIFF
--- a/bcs/network/p2pv2/stream_pool.go
+++ b/bcs/network/p2pv2/stream_pool.go
@@ -77,7 +77,7 @@ func (sp *StreamPool) Get(ctx xctx.XContext, peerId peer.ID) (*Stream, error) {
 	netStream, err := sp.srv.host.NewStream(sp.ctx, peerId, protocol.ID(protocolID))
 	if err != nil {
 		if errors.Is(err, swarm.ErrDialToSelf) {
-			ctx.GetLog().Trace("new net stream error", "peerId", peerId, "error", err)
+			ctx.GetLog().Info("new net stream error", "peerId", peerId, "error", err)
 			return nil, ErrNewStream
 		}
 		ctx.GetLog().Warn("new net stream error", "peerId", peerId, "error", err)

--- a/bcs/network/p2pv2/stream_pool.go
+++ b/bcs/network/p2pv2/stream_pool.go
@@ -7,6 +7,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
+	swarm "github.com/libp2p/go-libp2p-swarm"
 
 	xctx "github.com/xuperchain/xupercore/kernel/common/xcontext"
 	nctx "github.com/xuperchain/xupercore/kernel/network/context"
@@ -75,6 +76,10 @@ func (sp *StreamPool) Get(ctx xctx.XContext, peerId peer.ID) (*Stream, error) {
 
 	netStream, err := sp.srv.host.NewStream(sp.ctx, peerId, protocol.ID(protocolID))
 	if err != nil {
+		if errors.Is(err, swarm.ErrDialToSelf) {
+			ctx.GetLog().Trace("new net stream error", "peerId", peerId, "error", err)
+			return nil, ErrNewStream
+		}
 		ctx.GetLog().Warn("new net stream error", "peerId", peerId, "error", err)
 		return nil, ErrNewStream
 	}


### PR DESCRIPTION
## Description

代码中关于peerids的获取是经过kaddht句柄从底层libp2p库获取到然后经过multi过滤器过滤，此处暂未处理获取peerids的流程，仅当上述错误出现时由warn级别改为info日志级别

Fixes # (issue)
【日志】【优化】tdpos共识，日志频繁刷跟自己建立p2p连接的日志，需优化

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

仅当"dial to self attempted"错误出现时由warn级别改为info日志级别

## How Has This Been Tested?

部署运行，查看xchain.log.wf日志中是否出现warn级别的"dial to self attempted"日志
