### PR TITLE
问题：poa和pos类共识配置如果init_proposer参数为空会导致panic或者节点无法出块的错误 (#301)

### DIFF
--- a/bcs/consensus/tdpos/common.go
+++ b/bcs/consensus/tdpos/common.go
@@ -152,6 +152,17 @@ func buildConfigs(input []byte) (*tdposConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal to temp struct failed.err:%v", err)
 	}
+
+	// 校验是否输入初始候选人节点列表
+	if temp.InitProposer != nil {
+		// 二次校验
+		if addrs, ok := temp.InitProposer["1"]; !ok || len(addrs) <= 0 {
+			return nil, fmt.Errorf("init_proposer[\"1\"] is required")
+		}
+	} else {
+		return nil, fmt.Errorf("init_proposer is required")
+	}
+
 	tdposCfg.InitProposer = temp.InitProposer
 	tdposCfg.EnableBFT = temp.EnableBFT
 

--- a/bcs/consensus/xpoa/xpoa.go
+++ b/bcs/consensus/xpoa/xpoa.go
@@ -65,6 +65,13 @@ func NewXpoaConsensus(cCtx cctx.ConsensusCtx, cCfg def.ConsensusConfig) base.Con
 		cCtx.XLog.Error("consensus:xpoa:NewXpoaConsensus: xpoa struct unmarshal error", "error", err)
 		return nil
 	}
+
+	// 校验初始候选人节点列表
+	if len(xconfig.InitProposer.Address) <= 0 {
+		cCtx.XLog.Error("consensus:xpoa:NewXpoaConsensus: config init_proposer.address is required")
+		return nil
+	}
+
 	version, err := ParseVersion(cCfg.Config)
 	if err != nil {
 		cCtx.XLog.Error("consensus:xpoa:NewXpoaConsensus: version error", "error", err)


### PR DESCRIPTION
## Description

poa和pos类共识配置如果init_proposer参数为空会导致panic或者节点无法出块的错误

Fixes # (issue)
增加参数校验

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

poa和pos类共识实例创建的时候增加init_proposer参数校验，校验失败返回错误

## How Has This Been Tested?

升级到poa和pos类共识时desc文件内部缺少init_proposer参数会导致共识升级失败
错误日志标签：

升级到tdpos：init_proposer is required 或者 init_proposer["1"] is required
升级到poa：init_proposer.address is required
