### PR TITLE
fix range tx order for readonly and write tx

### DIFF
--- a/bcs/ledger/xledger/state/state.go
+++ b/bcs/ledger/xledger/state/state.go
@@ -480,7 +480,7 @@ func (t *State) PlayAndRepost(blockid []byte, needRepost bool, isRootTx bool) er
 	t.utxo.Mutex.Lock()
 	defer func() {
 		t.utxo.Mutex.Unlock()
-		metrics.StateUnconfirmedTxGauge.WithLabelValues(t.sctx.BCName).Set(float64(t.tx.UnconfirmTxAmount))
+		metrics.StateUnconfirmedTxGauge.WithLabelValues(t.sctx.BCName).Set(float64(t.tx.Mempool.GetTxCounnt()))
 		metrics.CallMethodHistogram.WithLabelValues(t.sctx.BCName, "PlayAndRepost").Observe(time.Since(beginTime).Seconds())
 	}()
 	timer.Mark("get_utxo_lock")

--- a/bcs/ledger/xledger/tx/mempool_test.go
+++ b/bcs/ledger/xledger/tx/mempool_test.go
@@ -513,7 +513,14 @@ func setup(m *Mempool) {
 					},
 				},
 			}
-			m.PutTx(tx1)
+			if string(tx1.Txid) == "500000" {
+				b := time.Now()
+				m.PutTx(tx1)
+				fmt.Println("PutTx 500000: ", time.Since(b))
+			} else {
+				m.PutTx(tx1)
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
在一个区块打包交易时，如果存在针对同一个 key 的只读和读写交易，需要保证先打包只读交易，然后打包读写交易。方案时在交易加入 mempool 时判断有没有其他交易和此交易符合这种情况，如果有将只读交易看做是读写交易的前置打包交易（必须在写交易前打包），将写交易看做读交易的后置打包交易（必须在读交易之后打包）。在打包时判断是否存在这种前置或者后置打包交易。