### PR TITLE
状态机在walk验证区块执行timer合约时检查autoTx.TxOutputsExt为空时返回错误，导致停止出块

### DIFF
--- a/bcs/ledger/xledger/state/tx_verification.go
+++ b/bcs/ledger/xledger/state/tx_verification.go
@@ -160,9 +160,9 @@ func (t *State) ImmediateVerifyAutoTx(blockHeight int64, tx *pb.Transaction, isR
 		t.log.Warn("get timer tasks failed", "err", genErr)
 		return false, genErr
 	}
-	if len(autoTx.TxOutputsExt) == 0 {
-		return false, fmt.Errorf("get timer tasks failed, no tx outputs ext")
-	}
+	//if len(autoTx.TxOutputsExt) == 0 {
+	//	return false, fmt.Errorf("get timer tasks failed, no tx outputs ext")
+	//}
 
 	// Pre processing of tx data
 	if !isRootTx && tx.Version == RootTxVersion {


### PR DESCRIPTION
## Description

状态机在walk验证区块执行timer合约时检查autoTx.TxOutputsExt为空时返回错误，导致停止出块

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

区块验证时不检查timer_task合约执行的读写集输出

## How Has This Been Tested?

节点验证区块timer合约结果集输出为空时，仍可继续出块
