### PR TITLE
Added error block and faulty node caching functions to improve stability, and increased the configuration of the p2p node selection strategy when synchronizing blocks

### DIFF
--- a/bcs/network/p2pv2/client.go
+++ b/bcs/network/p2pv2/client.go
@@ -237,7 +237,7 @@ func (p *P2PServerV2) getFilter(msg *pb.XuperMessage, opt *p2p.Option) PeerFilte
 		case p2p.NearestBucketStrategy:
 			filter = &NearestBucketFilter{srv: p}
 		case p2p.BucketsWithFactorStrategy:
-			filter = &BucketsFilterWithFactor{srv: p}
+			filter = &BucketsFilterWithFactor{srv: p, factor: opt.Factor}
 		default:
 			filter = &BucketsFilter{srv: p}
 		}

--- a/bcs/network/p2pv2/server.go
+++ b/bcs/network/p2pv2/server.go
@@ -51,6 +51,8 @@ var (
 
 	// MaxBroadCastPeers define the maximum number of common peers to broadcast messages
 	MaxBroadCastPeers = 20
+
+	DefaultBucketsFilterFactor = 0.5
 )
 
 // define errors

--- a/kernel/engines/xuperos/common/const.go
+++ b/kernel/engines/xuperos/common/const.go
@@ -17,3 +17,11 @@ const (
 	// 其他节点使用Interactive_BroadCast_Mode模式广播区块
 	MixedBroadCastMode
 )
+
+// 同步模式
+const (
+	// SyncWithNearestBucket 从邻近节点同步区块
+	SyncWithNearestBucket = iota
+	// SyncWithFactorBucket 从每个bucket中抽取节点同步区块
+	SyncWithFactorBucket
+)

--- a/kernel/engines/xuperos/config/config.go
+++ b/kernel/engines/xuperos/config/config.go
@@ -25,6 +25,10 @@ type EngineConf struct {
 	TxIdCacheGCInterval time.Duration `yaml:"txIdCacheGCInterval,omitempty"`
 	// MaxBlockQueueSize the queue size of the processing block
 	MaxBlockQueueSize int64 `yaml:"maxBlockQueueSize,omitempty"`
+	// SyncBlockFilterMode is the mode for filter peerID list policies, 0-SyncWithNearestBucket, 1-SyncWithFactorBucket
+	SyncBlockFilterMode int `yaml:"syncBlockFilterMode,omitempty"`
+	// SyncFactorForFactorBucketMode only use for SyncWithFactorBucket mode of SyncBlockFilterMode configuration item
+	SyncFactorForFactorBucketMode float64 `yaml:"SyncFactorForFactorBucketMode,omitempty"`
 }
 
 func LoadEngineConf(cfgFile string) (*EngineConf, error) {
@@ -39,11 +43,13 @@ func LoadEngineConf(cfgFile string) (*EngineConf, error) {
 
 func GetDefEngineConf() *EngineConf {
 	return &EngineConf{
-		RootChain:            RootBlockChain,
-		BlockBroadcastMode:   0,
-		TxIdCacheExpiredTime: 180 * time.Second,
-		TxIdCacheGCInterval:  300 * time.Second,
-		MaxBlockQueueSize:    100,
+		RootChain:                     RootBlockChain,
+		BlockBroadcastMode:            0,
+		TxIdCacheExpiredTime:          180 * time.Second,
+		TxIdCacheGCInterval:           300 * time.Second,
+		MaxBlockQueueSize:             100,
+		SyncBlockFilterMode:           0,
+		SyncFactorForFactorBucketMode: 0.5,
 	}
 }
 

--- a/kernel/network/p2p/option.go
+++ b/kernel/network/p2p/option.go
@@ -9,6 +9,8 @@ type Option struct {
 	WhiteList map[string]bool
 
 	Percent float32 // percent wait for return
+
+	Factor float64
 }
 
 // OptionFunc define single Option function for send message
@@ -52,6 +54,12 @@ func WithPeerIDs(peerIDs []string) OptionFunc {
 func WithAccounts(accounts []string) OptionFunc {
 	return func(o *Option) {
 		o.Accounts = accounts
+	}
+}
+
+func WithFactor(factor float64) OptionFunc {
+	return func(o *Option) {
+		o.Factor = factor
 	}
 }
 


### PR DESCRIPTION


## Description

1. 同步最长链时增加了错误区块缓存功能
2. 增加同步区块时过滤模式的配置和过滤factor配置，通过配置可以选择BucketsFilterWithFactor模式或者NearestBucketFilter模式
3. 重现编写BucketsFilterWithFactor的Filter函数，优化原始的过滤的逻辑，优化步骤

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
