### PR TITLE
add check tx already in db when post tx

### DIFF
--- a/kernel/engines/xuperos/chain.go
+++ b/kernel/engines/xuperos/chain.go
@@ -273,7 +273,7 @@ func (t *Chain) SubmitTx(ctx xctx.XContext, tx *lpb.Transaction) error {
 
 	// 判断此交易是否已经存在（账本和未确认交易表中）。
 	dbtx, _, _ := t.ctx.State.QueryTx(tx.GetTxid())
-	if dbtx != nil { // 从数据库查询失败。
+	if dbtx != nil { // 从数据库查询到了交易，返回错误。
 		log.Error("tx already exist", "txid", utils.F(tx.GetTxid()))
 		return common.ErrTxAlreadyExist
 	}

--- a/kernel/engines/xuperos/chain.go
+++ b/kernel/engines/xuperos/chain.go
@@ -272,18 +272,14 @@ func (t *Chain) SubmitTx(ctx xctx.XContext, tx *lpb.Transaction) error {
 	}()
 
 	// 判断此交易是否已经存在（账本和未确认交易表中）。
-	dbtx, confirmed, err := t.ctx.State.QueryTx(tx.GetTxid())
-	if err != nil { // 从数据库查询失败。
-		log.Error("check tx already exist failed", "txid", utils.F(tx.GetTxid()), "err", err)
-		return common.ErrTxVerifyFailed.More("err:%v", err)
-	}
-	if dbtx != nil { // 数据库存在此交易，重复提交。
-		log.Error("tx already exist in db", "txid", utils.F(tx.GetTxid()), "confirmed", confirmed)
+	dbtx, _, _ := t.ctx.State.QueryTx(tx.GetTxid())
+	if dbtx != nil { // 从数据库查询失败。
+		log.Error("tx already exist", "txid", utils.F(tx.GetTxid()))
 		return common.ErrTxAlreadyExist
 	}
 
 	// 验证交易
-	_, err = t.ctx.State.VerifyTx(tx)
+	_, err := t.ctx.State.VerifyTx(tx)
 	if err != nil {
 		log.Error("verify tx error", "txid", utils.F(tx.GetTxid()), "err", err)
 		code = "VerifyTxFailed"


### PR DESCRIPTION
PostTx 时检查交易是否已经存在账本或者未确认交易表中，在特殊情况下不加此检查会导致区块打包失败。