### PR TITLE
Fix the error that evm contract deployment and calling transaction are in the same block

### DIFF
--- a/bcs/contract/xvm/code_manager_test.go
+++ b/bcs/contract/xvm/code_manager_test.go
@@ -26,6 +26,14 @@ func (m *memCodeProvider) GetContractAbi(name string) ([]byte, error) {
 	return m.abi, nil
 }
 
+func (c *memCodeProvider) GetContractCodeFromCache(name string) ([]byte, error) {
+	return c.code, nil
+}
+
+func (c *memCodeProvider) GetContractAbiFromCache(name string) ([]byte, error) {
+	return c.abi, nil
+}
+
 type fakeCode struct {
 }
 

--- a/bcs/ledger/xledger/state/tx_verification.go
+++ b/bcs/ledger/xledger/state/tx_verification.go
@@ -631,6 +631,9 @@ func (t *State) verifyTxRWSets(tx *pb.Transaction) (bool, error) {
 			contextConfig.TransferAmount = ""
 		}
 
+		if len(tx.Blockid) != 0 {
+			contextConfig.TxInBlock = true
+		}
 		ctx, err := t.sctx.ContractMgr.NewContext(contextConfig)
 		if err != nil {
 			t.log.Error("verifyTxRWSets NewContext error", "err", err, "contractName", tmpReq.GetContractName())

--- a/bcs/ledger/xledger/state/xmodel/xmodel_snapshot.go
+++ b/bcs/ledger/xledger/state/xmodel/xmodel_snapshot.go
@@ -99,6 +99,10 @@ func (t *xModSnapshot) getBlockHeight(blockid []byte) (int64, error) {
 	return blkInfo.Height, nil
 }
 
+func (t *xModSnapshot) GetUncommited(bucket string, key []byte) (*kledger.VersionedData, error) {
+	return nil, fmt.Errorf("not support")
+}
+
 func (t *xModSnapshot) genVerDataByTx(tx *pb.Transaction, offset int32) *kledger.VersionedData {
 	if tx == nil || int(offset) >= len(tx.TxOutputsExt) || offset < 0 {
 		return nil

--- a/kernel/consensus/mock/mock_pluggable_consensus.go
+++ b/kernel/consensus/mock/mock_pluggable_consensus.go
@@ -434,6 +434,10 @@ func (r *FakeXMReader) Select(bucket string, startKey []byte, endKey []byte) (le
 	return nil, nil
 }
 
+func (r *FakeXMReader) GetUncommited(bucket string, key []byte) (*ledger.VersionedData, error) {
+	return nil, fmt.Errorf("not support")
+}
+
 func NewXContent() *xctx.BaseCtx {
 	return &xctx.BaseCtx{}
 }

--- a/kernel/contract/bridge/code_provider.go
+++ b/kernel/contract/bridge/code_provider.go
@@ -11,6 +11,10 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
+type stateGetReader interface {
+	Get(bucket string, key []byte) ([]byte, error)
+}
+
 type stateReader interface {
 	Get(bucket string, key []byte) ([]byte, error)
 	GetUncommited(bucket string, key []byte) (*ledger.VersionedData, error)
@@ -63,6 +67,22 @@ func newCodeProviderFromXMReader(r ledger.XMReader) ContractCodeProvider {
 func newCodeProvider(xstore stateReader) ContractCodeProvider {
 	return &codeProvider{
 		xstore: xstore,
+	}
+}
+
+type stateReaderWrapper struct {
+	stateGetReader
+}
+
+func (s *stateReaderWrapper) GetUncommited(bucket string, key []byte) (*ledger.VersionedData, error) {
+	return nil, fmt.Errorf("not support")
+}
+
+func newCodeProviderWithCache(xstore stateGetReader) ContractCodeProvider {
+	return &codeProvider{
+		xstore: &stateReaderWrapper{
+			stateGetReader: xstore,
+		},
 	}
 }
 

--- a/kernel/contract/bridge/context.go
+++ b/kernel/contract/bridge/context.go
@@ -53,6 +53,9 @@ type Context struct {
 
 	// Write by contract
 	Output *pb.Response
+
+	// Read from cache
+	ReadFromCache bool
 }
 
 // DiskUsed returns the bytes written to xmodel

--- a/kernel/contract/bridge/contract_manager.go
+++ b/kernel/contract/bridge/contract_manager.go
@@ -77,7 +77,7 @@ func (c *contractManager) DeployContract(kctx contract.KContext) (*contract.Resp
 	if creator == nil {
 		return nil, contract.Limits{}, fmt.Errorf("contract type %s not found", contractType)
 	}
-	cp := newCodeProvider(state)
+	cp := newCodeProviderWithCache(state)
 	instance, err := creator.CreateInstance(&Context{
 		State:          state,
 		ContractName:   contractName,
@@ -155,7 +155,7 @@ func (c *contractManager) UpgradeContract(kctx contract.KContext) (*contract.Res
 	store.Put("contract", ContractCodeDescKey(contractName), descbuf)
 	store.Put("contract", contractCodeKey(contractName), code)
 
-	cp := newCodeProvider(store)
+	cp := newCodeProviderWithCache(store)
 
 	contractType, err := getContractType(desc)
 	if err != nil {

--- a/kernel/contract/bridge/vm.go
+++ b/kernel/contract/bridge/vm.go
@@ -26,6 +26,8 @@ type ContractCodeProvider interface {
 	GetContractCodeDesc(name string) (*protos.WasmCodeDesc, error)
 	GetContractCode(name string) ([]byte, error)
 	GetContractAbi(name string) ([]byte, error)
+	GetContractCodeFromCache(name string) ([]byte, error)
+	GetContractAbiFromCache(name string) ([]byte, error)
 }
 
 // InstanceCreator is the creator of contract virtual machine instance

--- a/kernel/contract/bridge/xbridge.go
+++ b/kernel/contract/bridge/xbridge.go
@@ -117,15 +117,20 @@ func (v *XBridge) NewContext(ctxCfg *contract.ContextConfig) (contract.Context, 
 		return nil, fmt.Errorf("vm for contract type %s not supported", tp)
 	}
 	var cp ContractCodeProvider
-	// 如果当前在部署合约，合约代码从cache获取
-	// 合约调用的情况则从model中拿取合约代码，避免交易中包含合约代码的引用。
+
+	ctx := v.ctxmgr.MakeContext()
+
+	// 1. 如果当前在部署合约，合约代码从sandbox中获取
+	// 2. 合约调用的情况则从model中拿取合约代码，避免交易中包含合约代码的引用
+	// 2.1 wasm与native有本地缓存，所以对代码的读取是不确定的，所以不能在读集中出现合约代码引用
+	// 2.2 由于evm合约没有本地缓存，所以如果部署和调用在同一个区块时需要从底层batchCache缓存中读取
+	ctx.ReadFromCache = ctxCfg.TxInBlock
 	if ctxCfg.ContractCodeFromCache {
+		ctx.ReadFromCache = false
 		cp = newCodeProvider(ctxCfg.State)
 	} else {
 		cp = newDescProvider(v.codeProvider, desc)
 	}
-
-	ctx := v.ctxmgr.MakeContext()
 	ctx.State = ctxCfg.State
 	ctx.Core = v.core
 	ctx.Module = ctxCfg.Module
@@ -156,7 +161,6 @@ func (v *XBridge) NewContext(ctxCfg *contract.ContextConfig) (contract.Context, 
 	release := func() {
 		v.ctxmgr.DestroyContext(ctx)
 	}
-
 	instance, err := vm.CreateInstance(ctx, cp)
 	if err != nil {
 		v.ctxmgr.DestroyContext(ctx)

--- a/kernel/contract/bridge/xbridge.go
+++ b/kernel/contract/bridge/xbridge.go
@@ -103,7 +103,7 @@ func (v *XBridge) NewContext(ctxCfg *contract.ContextConfig) (contract.Context, 
 		}
 	} else {
 		// test if contract exists
-		desc, err = newCodeProvider(ctxCfg.State).GetContractCodeDesc(ctxCfg.ContractName)
+		desc, err = newCodeProviderWithCache(ctxCfg.State).GetContractCodeDesc(ctxCfg.ContractName)
 		if err != nil {
 			return nil, err
 		}
@@ -127,7 +127,7 @@ func (v *XBridge) NewContext(ctxCfg *contract.ContextConfig) (contract.Context, 
 	ctx.ReadFromCache = ctxCfg.TxInBlock
 	if ctxCfg.ContractCodeFromCache {
 		ctx.ReadFromCache = false
-		cp = newCodeProvider(ctxCfg.State)
+		cp = newCodeProviderWithCache(ctxCfg.State)
 	} else {
 		cp = newDescProvider(v.codeProvider, desc)
 	}

--- a/kernel/contract/context.go
+++ b/kernel/contract/context.go
@@ -52,4 +52,6 @@ type ContextConfig struct {
 
 	// ContractCodeFromCache control whether fetch contract code from XMCache
 	ContractCodeFromCache bool
+
+	TxInBlock bool
 }

--- a/kernel/contract/sandbox/mem_xmodel.go
+++ b/kernel/contract/sandbox/mem_xmodel.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"bytes"
 	"errors"
+	"fmt"
 
 	"github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/emirpasic/gods/utils"
@@ -43,6 +44,10 @@ func (m *MemXModel) Put(bucket string, key []byte, value *ledger.VersionedData) 
 	buKey := makeRawKey(bucket, key)
 	m.tree.Put(buKey, value)
 	return nil
+}
+
+func (t *MemXModel) GetUncommited(bucket string, key []byte) (*ledger.VersionedData, error) {
+	return nil, fmt.Errorf("not support")
 }
 
 // Select 扫描一个bucket中所有的kv, 调用者可以设置key区间[startKey, endKey)

--- a/kernel/contract/sandbox/xmcache.go
+++ b/kernel/contract/sandbox/xmcache.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/xuperchain/xupercore/bcs/ledger/xledger/state/utxo"
@@ -88,6 +89,10 @@ func (xc *XMCache) Get(bucket string, key []byte) ([]byte, error) {
 		return nil, ErrHasDel
 	}
 	return verData.GetPureData().GetValue(), nil
+}
+
+func (t *XMCache) GetUncommited(bucket string, key []byte) (*ledger.VersionedData, error) {
+	return nil, fmt.Errorf("not support")
 }
 
 // Level1 读取，从outputsCache中读取

--- a/kernel/contract/state.go
+++ b/kernel/contract/state.go
@@ -63,6 +63,7 @@ type StateSandbox interface {
 	Flush() error
 	RWSet() *RWSet
 	UTXORWSet() *UTXORWSet
+	GetUncommited(bucket string, key []byte) (*ledger.VersionedData, error)
 }
 
 type RWSet struct {

--- a/kernel/contract/state.go
+++ b/kernel/contract/state.go
@@ -63,7 +63,6 @@ type StateSandbox interface {
 	Flush() error
 	RWSet() *RWSet
 	UTXORWSet() *UTXORWSet
-	GetUncommited(bucket string, key []byte) (*ledger.VersionedData, error)
 }
 
 type RWSet struct {

--- a/kernel/ledger/interface.go
+++ b/kernel/ledger/interface.go
@@ -27,7 +27,7 @@ type XMReader interface {
 	Get(bucket string, key []byte) (*VersionedData, error)
 	//扫描一个bucket中所有的kv, 调用者可以设置key区间[startKey, endKey)
 	Select(bucket string, startKey []byte, endKey []byte) (XMIterator, error)
-	//
+	//从区块缓存中读取数据信息
 	GetUncommited(bucket string, key []byte) (*VersionedData, error)
 }
 

--- a/kernel/ledger/interface.go
+++ b/kernel/ledger/interface.go
@@ -27,6 +27,8 @@ type XMReader interface {
 	Get(bucket string, key []byte) (*VersionedData, error)
 	//扫描一个bucket中所有的kv, 调用者可以设置key区间[startKey, endKey)
 	Select(bucket string, startKey []byte, endKey []byte) (XMIterator, error)
+	//
+	GetUncommited(bucket string, key []byte) (*VersionedData, error)
 }
 
 // XMIterator iterates over key/value pairs in key order


### PR DESCRIPTION
…e in the same block

## Description

evm合约部署和调用如果在同一区块中，会导致同步区块执行调用合约时无法读取到合约code

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

evm合约执行时，如果是区块内交易则从本地区块级别缓存中读取数据

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
