### PR TITLE
Fix the problem of iterating panic when the parameter is wrong

### DIFF
--- a/kernel/contract/sandbox/xmcache.go
+++ b/kernel/contract/sandbox/xmcache.go
@@ -162,10 +162,16 @@ func (xc *XMCache) Select(bucket string, startKey []byte, endKey []byte) (contra
 
 // newXModelCacheIterator new an instance of XModel Cache iterator
 func (mc *XMCache) newXModelCacheIterator(bucket string, startKey []byte, endKey []byte) (contract.Iterator, error) {
-	iter, _ := mc.outputsCache.Select(bucket, startKey, endKey)
+	iter, err := mc.outputsCache.Select(bucket, startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
 	outputIter := iter
 
-	iter, _ = mc.inputsCache.Select(bucket, startKey, endKey)
+	iter, err = mc.inputsCache.Select(bucket, startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
 	inputIter := newStripDelIterator(iter)
 
 	backendIter, err := mc.model.Select(bucket, startKey, endKey)


### PR DESCRIPTION
## Description

Fix the problem of iterating panic when the parameter is wrong

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
