### PR TITLE
修改contractNameMaxSize最大长度为64

### DIFF
--- a/kernel/contract/util.go
+++ b/kernel/contract/util.go
@@ -10,7 +10,7 @@ var (
 )
 
 const (
-	contractNameMaxSize = 16
+	contractNameMaxSize = 64
 	contractNameMinSize = 4
 )
 

--- a/kernel/permission/acl/utils/def.go
+++ b/kernel/permission/acl/utils/def.go
@@ -7,7 +7,7 @@ const (
 
 const (
 	accountSize            = 16
-	contractNameMaxSize    = 16
+	contractNameMaxSize    = 64
 	contractNameMinSize    = 4
 	accountPrefix          = "XC"
 	accountBucket          = "XCAccount"


### PR DESCRIPTION
## Description

What is the purpose of the change?
默认的合约名长度16略短,修改为64

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


